### PR TITLE
Separate rephrase/chat self-reflection options

### DIFF
--- a/scripts/csv_data_rephrase.py
+++ b/scripts/csv_data_rephrase.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                     detoxified = tmarco.rephrase(value, tmarco.mask(value), combine_original=True)
                 elif kind == 'reflect':
                     if chat_model is not None:
-                        detoxified = tmarco.reflect(value, chat_model=chat_model)[0]
+                        detoxified = tmarco.reflect(value, chat_model=chat_model, conversation_type='chat')[0]
                     else:
                         detoxified = tmarco.reflect(value)[0]
                 else:


### PR DESCRIPTION
It is now possible to call `tmarco.reflect(text, conversation_type='rephrase')` (default) or `tmarco.reflect(text, conversation_type='chat')` depending both on the underlying model (the base model, _BART_ for conditional generation by default) or a supplied _chat_model_ that can be an external model/LLM (e.g. ´TinyLlama/TinyLlama-1.1B-Chat-v1.0´).